### PR TITLE
Switches to keyCode for browser support.

### DIFF
--- a/js/numeric-input.js
+++ b/js/numeric-input.js
@@ -43,8 +43,7 @@
 		39, // ArrowRight
 		37, // ArrowLeft
 		38, // ArrowUp
-		40, // ArrowDown
-		190 // .
+		40 // ArrowDown
 	];
 
 	NumericInput.prototype.initMaxlength = function(){
@@ -60,26 +59,21 @@
 
 	NumericInput.prototype.onKeydown = function( event ){
 		var prevented = false;
-
 		// The key pressed is allowed, no exceptions
 		// modifier keys and keys listed in allowedKeys property
+
 		if( this.isKeyAllowed( event ) ){
 			return;
 		}
-
-		if (event.key !== undefined) {
-			var key = event.key;
-			// handle anything that's not a number
-			prevented = isNaN(parseInt(key, 10));
-		} else if (event.keyCode !== undefined) {
+		if (event.keyCode !== undefined) {
 			var code = event.keyCode;
 			// allow '.', return
 			// disallow anything less than 48 or greater than 57
 			prevented = (code < 48 || code > 57) &&
-				code !== 13 &&
-				( !this.allowFloat || code !== 46 );
+				!this.isInputTextSelected() &&
+				( !this.allowFloat || code !== 190);
 
-			if( this.allowFloat && code === 46 && this.el.value.length && this.el.value.indexOf( '.' ) > -1 ) {
+			if( this.allowFloat && code === 190 && this.el.value.length && this.el.value.indexOf( '.' ) > -1 ) {
 				prevented = true;
 			}
 		}
@@ -132,7 +126,6 @@
 		} else if (document.selection && document.selection.type != "Control") {
 			selectionText = document.selection.createRange().text;
 		}
-
 		return selectionText ? this.$el.val().indexOf(selectionText) > -1 : false;
 	};
 

--- a/js/numeric-input.js
+++ b/js/numeric-input.js
@@ -31,20 +31,20 @@
 		this.$el.on( "focus", function( e ) {
 			self.initMaxlength();
 		}).on( "keydown", function( e ) {
-			self.onKeypress.call( self, e );
+			self.onKeydown.call( self, e );
 		});
 	};
 
 	NumericInput.allowedKeys = [
-		"Tab",
-		"Enter",
-		"Escape",
-		"Backspace",
-		"ArrowRight",
-		"ArrowLeft",
-		"ArrowUp",
-		"ArrowDown",
-		"."
+		9, // Tab
+		13, // Enter
+		27, //Escape
+		8, // Backspace
+		39, // ArrowRight
+		37, // ArrowLeft
+		38, // ArrowUp
+		40, // ArrowDown
+		190 // .
 	];
 
 	NumericInput.prototype.initMaxlength = function(){
@@ -58,7 +58,7 @@
 			Infinity;
 	};
 
-	NumericInput.prototype.onKeypress = function( event ){
+	NumericInput.prototype.onKeydown = function( event ){
 		var prevented = false;
 
 		// The key pressed is allowed, no exceptions
@@ -101,15 +101,17 @@
 	};
 
 	NumericInput.prototype.isKeyAllowed = function( event ) {
-		var isAllowed = false, key = event.key;
+		var isAllowed = false, key = event.keyCode;
 
 		// indexOf not supported everywhere for arrays
 		$.each(NumericInput.allowedKeys, function(i, e){
-			if( e === key ) { isAllowed = true;	 }
+			if( e === key ) {
+				isAllowed = true;
+			}
 		});
 
-		// the numeric navigation of values may be disabled
-		if( this.isNavDisabled && (key == "ArrowUp" || key == "ArrowDown") ){
+		// the up/down arrow key numeric navigation of values may be disabled
+		if( this.isNavDisabled && (key == 38 || key == 40) ){
 			isAllowed = false;
 		}
 


### PR DESCRIPTION
This is to fix the regression with Delete/Tab/Arrows on master with the change to `keydown`. This change exposed some other issues with the event whitelist that required moving to keycode instead of key.

Note that this PR also exposed #44, which existed on master branch prior to these changes.